### PR TITLE
Disable public template routing

### DIFF
--- a/config/craft/general.php
+++ b/config/craft/general.php
@@ -48,4 +48,7 @@ return [
 	'timezone' => 'America/New_York',
 
 	'maxUploadFileSize' => 524288000, // 500MB
+
+	// Disable public template routing (autogenerating routes from templates)
+	'privateTemplateTrigger' => '',
 ];


### PR DESCRIPTION
Currently if you have a template in `/templates` without a `_` prefix, Craft will automatically generate a Route matching that path for you. This can _seem_ useful, but **I'd argue is more likely to cause an issue than to be helpful**.

I argue that for a few reasons:
1. We don't always remember this and prefix our templates correctly, which can lead to unexpected routes and duplicate URLs.
2. Our filesystem shouldn't _have_ to mirror our URLs.
3. 95% of pages _should_ have a corresponding entry in Craft. Even something like a blog index page still needs at _least_ SEO fields in the CMS (even if it doesn't need any other fields). Pages like that should be a single mapped to a template.
4. If you _**really**_ want to have a route without an entry, you can create that easily using `config/craft/routes.php`